### PR TITLE
Removed unused import that was not included in dependencies

### DIFF
--- a/implementations/java/org.hl7.fhir.r4/src/org/hl7/fhir/r4/elementmodel/XmlParser.java
+++ b/implementations/java/org.hl7.fhir.r4/src/org/hl7/fhir/r4/elementmodel/XmlParser.java
@@ -53,8 +53,6 @@ import org.w3c.dom.Node;
 import org.xml.sax.InputSource;
 import org.xml.sax.XMLReader;
 
-import com.sun.webkit.ContextMenu.ShowContext;
-
 public class XmlParser extends ParserBase {
   private boolean allowXsiLocation;
 


### PR DESCRIPTION
In the XmlParser Java class under the r4 implementation, the unused import `com.sun.webkit.ContextMenu.ShowContext` was causing an error on the build. There is no dependencies included for WebKit and the class is never used.